### PR TITLE
Fix a crash if the pictures directory doesn’t exist

### DIFF
--- a/tedbottompicker/build.gradle
+++ b/tedbottompicker/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/ParkSangGwon/TedBottomPicker'
     gitUrl = 'https://github.com/ParkSangGwon/TedBottomPicker.git'
 
-    libraryVersion = '1.0.9'
+    libraryVersion = '1.0.10'
 
     developerId = 'gun0912'
     developerName = 'Ted Park'

--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
@@ -527,8 +527,13 @@ public class TedBottomPicker extends BottomSheetDialogFragment {
 
         String realPath = RealPathUtil.getRealPath(getActivity(), temp);
 
+        Uri selectedImageUri = null;
+        try {
+            selectedImageUri = Uri.fromFile(new File(realPath));
+        } catch (Exception ex) {
+            selectedImageUri = Uri.parse(realPath);
+        }
 
-        Uri selectedImageUri = Uri.fromFile(new File(realPath));
         complete(selectedImageUri);
 
     }

--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
@@ -400,6 +400,7 @@ public class TedBottomPicker extends BottomSheetDialogFragment {
             String imageFileName = "JPEG_" + timeStamp + "_";
             File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
 
+            storageDir.mkdirs();
 
             imageFile = File.createTempFile(
                     imageFileName,  /* prefix */

--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomPicker.java
@@ -400,7 +400,8 @@ public class TedBottomPicker extends BottomSheetDialogFragment {
             String imageFileName = "JPEG_" + timeStamp + "_";
             File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
 
-            storageDir.mkdirs();
+            if (!storageDir.exists())
+                storageDir.mkdirs();
 
             imageFile = File.createTempFile(
                     imageFileName,  /* prefix */


### PR DESCRIPTION
Fixes Issue #28 by calling "mkdirs" on the storage directory to ensure that the directories have been created.