### PR TITLE
예외처리 추가.

### DIFF
--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/adapter/GalleryAdapter.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/adapter/GalleryAdapter.java
@@ -99,6 +99,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.GalleryV
 
         } catch (Exception e) {
             e.printStackTrace();
+            throw new RuntimeException("error while loading images", e);
         } finally {
             if (cursor != null && !cursor.isClosed()) {
                 cursor.close();


### PR DESCRIPTION
GalleryAdapter에서 이미지를 불러올때 예외가 발생해도 아무 처리도 되고 있지 않습니다.
실제로 권한이 없어서 SecurityException이 발생할때도 아무것도 표시되지 않고있습니다.
예외에따라 분기해 각각 처리해주는게 좋다고 생각하지만 우선은 예외를 던져
상위 코드에서 에러를 인지할 수 있도록 해주는게 필요하다고 생각해 수정했습니다.