### PR TITLE
fix selection indicator at index 0

### DIFF
--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/adapter/GalleryAdapter.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/adapter/GalleryAdapter.java
@@ -125,7 +125,7 @@ public class GalleryAdapter extends RecyclerView.Adapter<GalleryAdapter.GalleryV
         }
 
 
-        if (position > 0) {
+        if (position >= 0) {
             notifyItemChanged(position);
         }
 


### PR DESCRIPTION
Fix: Selection indicator is not shown at index 0 (left top image) when use these options:

```
.showCameraTile(false)
.showGalleryTile(false)
```

---

```
.showCameraTile(false)
.showGalleryTile(false)
```

を使用した時に左上の画像が選択できない問題を修正
