### PR TITLE
add check if getActivity() == null

### DIFF
--- a/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomSheetDialogFragment.java
+++ b/tedbottompicker/src/main/java/gun0912/tedbottompicker/TedBottomSheetDialogFragment.java
@@ -409,7 +409,7 @@ public class TedBottomSheetDialogFragment extends BottomSheetDialogFragment {
                 .setListener(new OnActivityResultListener() {
                     @Override
                     public void onActivityResult(int resultCode, Intent data) {
-                        if (resultCode == Activity.RESULT_OK) {
+                        if (getActivity() != null && resultCode == Activity.RESULT_OK) {
                             onActivityResultCamera(cameraImageUri);
                         }
                     }
@@ -507,7 +507,7 @@ public class TedBottomSheetDialogFragment extends BottomSheetDialogFragment {
                 .setListener(new OnActivityResultListener() {
                     @Override
                     public void onActivityResult(int resultCode, Intent data) {
-                        if (resultCode == Activity.RESULT_OK) {
+                        if (getActivity() != null && resultCode == Activity.RESULT_OK) {
                             onActivityResultGallery(data);
                         }
                     }


### PR DESCRIPTION
TedBottomPicker uses ProxyActivity. and ProxyActivity stores ActivityRequest.
So if configuration change occurs, ActivityRequest's OnActivityResultListener reference destroyed TedBottomSheetDialogFragment. 
This causes runtime Exception.


`Failure delivering result ResultInfo{who=null, request=3457, result=-1, data=Intent { dat=content://media/external/images/media/7356 flg=0x1 (has extras) }} to activity {com.sample.android.demo/com.gun0912.tedonactivityresult.ProxyActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.PackageManager android.content.Context.getPackageManager()' on a null object reference
`

You can demonstrate this problem by enabling 'Don't keep activities' on the Developer Options In Android Phone Setting.

To solve this problem, we can either check getActivity() != null when invoking onActivityResult() or make ProxyActivity doesn't stores ActivityRequest. The former will skip processing the Activity result, but Runtime Exception will not occur.  The Latter takes so many changes. So, I choose the former.

